### PR TITLE
Displayname parameter fix

### DIFF
--- a/src/thoughtspot_rest_api_v1/tsrestapiv1.py
+++ b/src/thoughtspot_rest_api_v1/tsrestapiv1.py
@@ -488,7 +488,7 @@ class TSRestApiV1:
 
         post_data = {
             'name': group_name,
-            'display_name': display_name,
+            'displayname': display_name,
             'grouptype': group_type,
             'visibility': visibility
         }
@@ -1172,7 +1172,7 @@ class TSRestApiV1:
         post_data = {
             'name': username,
             'password': password,
-            'display_name': display_name,
+            'displayname': display_name,
             'usertype': user_type,
             'visibility': visibility
         }


### PR DESCRIPTION
The documentation of [user](https://developers.thoughtspot.com/docs/?pageid=user-api) and [group](https://developers.thoughtspot.com/docs/?pageid=group-api) mentions a `displayname` parameter. However, this library uses `display_name` instead of that (in the `user__post` and `group__post` methods). Because of this additional underscore, the parameter is not valid and post request results in an error (500). I have fixed this issue by removing the underscore from the parameter name.