### PR TITLE
group__post fix

### DIFF
--- a/src/thoughtspot_rest_api_v1/tsrestapiv1.py
+++ b/src/thoughtspot_rest_api_v1/tsrestapiv1.py
@@ -511,13 +511,13 @@ class TSRestApiV1:
 
         post_data = {
             'name': group_name,
-            'displayname': display_name,
+            'display_name': display_name,
             'grouptype': group_type,
             'visibility': visibility
         }
 
         if privileges is not None:
-            post_data['privileges'] = json.dumps(privileges)
+            post_data['privileges'] = privileges
         if tenant_id is not None:
             post_data['tenantid'] = tenant_id
 


### PR DESCRIPTION
These changes to group__post are the only way I could manage to get it working:
1. The displayname parameter needs an underscore - i.e. display_name
2. The privileges parameter is changed to accept the raw text supplied and if the DATADOWNLOADING privilege is required, then supply "[DATADOWNLOADING]"
Tony