### PR TITLE
JSONDecodeError fix

### DIFF
--- a/src/thoughtspot_rest_api_v1/tsrestapiv1.py
+++ b/src/thoughtspot_rest_api_v1/tsrestapiv1.py
@@ -1362,7 +1362,6 @@ class TSRestApiV1:
         url = self.base_url + endpoint
         response = self.session.put(url=url, data=post_data)
         response.raise_for_status()
-        return response.json()
 
     def user_updatepassword(self, username: str, current_password: str, new_password: str):
         endpoint = 'user/updatepassword'
@@ -1516,7 +1515,6 @@ class TSRestApiV1:
 
         response = self.session.put(url=url, params=url_params)
         response.raise_for_status()
-        return response.json()
 
     # Adds to existing group membership?
     def user_groups__delete(self, user_guid: str, group_guids: List[str]):
@@ -1529,7 +1527,6 @@ class TSRestApiV1:
 
         response = self.session.delete(url=url, params=url_params)
         response.raise_for_status()
-        return response.json()
 
     def user_session_invalidate(self, usernames: Optional[List[str]] = None, user_guids: Optional[List[str]] = None):
         if usernames is None and user_guids is None:


### PR DESCRIPTION
Returning `response.json()` throws a `requests.exceptions.JSONDecodeError` exception in several methods. Therefore, I removed the return statements from the ones that I tried (`user_groups__post`, `user_groups__delete` and `user__put`).