### PR TITLE
Update TSRestAPIV1.session_auth_token with correct Accept header

### DIFF
--- a/src/thoughtspot_rest_api_v1/tsrestapiv1.py
+++ b/src/thoughtspot_rest_api_v1/tsrestapiv1.py
@@ -1387,7 +1387,7 @@ class TSRestApiV1:
 
         url = self.base_url + endpoint
 
-        response = self.requests_session.post(url=url, data=post_params)
+        response = self.requests_session.post(url=url, data=post_params, headers={"Accept": "text/plain"})
         return response
 
     # session/login/token is typically only used within the browser and handled by the Visual Embed SDK,


### PR DESCRIPTION
The endpoint `v1/session/auth/token` requires that the Accept header include `text/plain`.

If it is not present a 406 will be returned with no details explaining the failure.

This PR overrides the Accept header for only the `session_auth_token` method so end user clients do not have to do this via the request session object instead.