### PR TITLE
remove restrictions to give identifier on APIv2 tags_search

### DIFF
--- a/src/thoughtspot_rest_api_v1/tsrestapiv2.py
+++ b/src/thoughtspot_rest_api_v1/tsrestapiv2.py
@@ -358,8 +358,6 @@ class TSRestApiV2:
     #
     def tags_search(self, tag_identifier: Optional[str] = None, color: Optional[str] = None):
         endpoint = 'tags/search'
-        if tag_identifier is None and color is None:
-            raise Exception("Must provide tag_identifier or color")
         request = {}
         if tag_identifier is not None:
             request['tag_identifier'] = tag_identifier


### PR DESCRIPTION
fixes issue #15

there is no need for this restriction as the API does not enforce this behaviour.